### PR TITLE
feat: add timeout to force manual capture on error

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,8 +6,8 @@ android {
         applicationId "com.example.camerabioexample_android"
         minSdkVersion 19
         targetSdkVersion 28
-        versionCode 6
-        versionName "2.3.2"
+        versionCode 7
+        versionName "2.4.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }

--- a/camerabioandroid/src/main/java/com/example/camerabioandroid/camerabiomanager/SelfieActivity.java
+++ b/camerabioandroid/src/main/java/com/example/camerabioandroid/camerabiomanager/SelfieActivity.java
@@ -56,6 +56,7 @@ public class SelfieActivity extends Camera2Base implements ImageProcessor, Captu
             "Gire um pouco a direita",
             "Rosto não identificado",
             "Rosto inclinado"} ;
+    private final String manualCaptureMessage = "Pressione o botão para tirar a foto";
 
     private int erroIndex = -1;
     private boolean faceOK = true;
@@ -134,6 +135,9 @@ public class SelfieActivity extends Camera2Base implements ImageProcessor, Captu
     private Boolean autoCapture;
     private Boolean countRegressive;
 
+    // contador de erro
+    private CountDownTimer errorCountDownTimer;
+    private Boolean forcedManualCapture = Boolean.FALSE;
 
     private static CameraBioManager cameraBioManager;
 
@@ -349,7 +353,6 @@ public class SelfieActivity extends Camera2Base implements ImageProcessor, Captu
                                 }
                                 else {
                                     markRed();
-                                    takePictureImageButton.setEnabled(false);
                                 }
                                 // exibe as grides em tela (caso ativo)
                                 if (showLines) {
@@ -363,20 +366,20 @@ public class SelfieActivity extends Camera2Base implements ImageProcessor, Captu
                             else {
                                 erroIndex = 7;
                                 markRed();
-                                takePictureImageButton.setEnabled(false);
                             }
                         }
                         else {
                             erroIndex = 7;
                             markRed();
-                            takePictureImageButton.setEnabled(false);
                         }
 
                         runOnUiThread(new Runnable() {
                             @Override
                             public void run() {
 
-                                if (erroIndex != -1) {
+                                if (erroIndex != -1 && forcedManualCapture) {
+                                    showFastToast(manualCaptureMessage);
+                                } else if (erroIndex != -1) {
                                     showFastToast(mensagens[erroIndex]);
                                 } else if (toast != null) {
                                     toast.cancel();
@@ -434,6 +437,32 @@ public class SelfieActivity extends Camera2Base implements ImageProcessor, Captu
         }
     }
 
+    private void destroyErrorTimer () {
+        if (errorCountDownTimer != null) {
+            errorCountDownTimer.cancel();
+            errorCountDownTimer = null;
+        }
+    }
+
+    private void createErrorTimer () {
+        if (errorCountDownTimer == null && !forcedManualCapture) {
+            takePictureImageButton.setEnabled(false);
+            errorCountDownTimer = new CountDownTimer(5000, 1000) {
+
+                public void onTick(long millisUntilFinished) {}
+
+                public void onFinish() {
+                    autoCapture = Boolean.FALSE;
+                    forcedManualCapture = Boolean.TRUE;
+                    takePictureImageButton.setEnabled(true);
+                    markBlue();
+                }
+
+            };
+            errorCountDownTimer.start();
+        }
+    }
+
     private void autoCapture () {
 
         if(countDownTimer == null && isRequestImage == false) {
@@ -464,6 +493,7 @@ public class SelfieActivity extends Camera2Base implements ImageProcessor, Captu
     }
 
     private void markBlue() {
+        destroyErrorTimer();
 
         erroIndex =-1;
 
@@ -487,8 +517,9 @@ public class SelfieActivity extends Camera2Base implements ImageProcessor, Captu
 
     private void markRed() {
         destroyTimer();
+        createErrorTimer();
 
-        if (!countDownCancelled[0]) {
+        if (!countDownCancelled[0] && !forcedManualCapture) {
             int size = 18;
             if (screenWidth > 1600) {
                 size = 34;


### PR DESCRIPTION
https://dev.azure.com/Ton-Dev/BANKING%20-%20CONTA%20TON/_workitems/edit/16086

Após 5 segundos com erro para identificar o rosto, possibilita tirar foto manualmente.